### PR TITLE
Updates to better support .net core memory dumps

### DIFF
--- a/MemoScope/App.config
+++ b/MemoScope/App.config
@@ -2,8 +2,8 @@
 <configuration>
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="nlog" type="NLog.Config.ConfigSectionHandler, NLog" />
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
@@ -14,6 +14,10 @@
       <dependentAssembly>
         <assemblyIdentity name="ObjectListView" publicKeyToken="b1c5bf581481bcd4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.9.0.25611" newVersion="2.9.0.25611" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WeifenLuo.WinFormsUI.Docking" publicKeyToken="5cded1a1a0a7b481" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.6.0" newVersion="3.0.6.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -38,10 +42,10 @@
       <logger name="MemoScope.Modules.RootPath.RootPathAnalysis" minlevel="Info" writeTo="Debug, File"></logger>
     </rules>
   </nlog>
-  
-<system.data>
+  <system.data>
     <DbProviderFactories>
       <remove invariant="System.Data.SQLite.EF6" />
       <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
     <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
-  </system.data></configuration>
+  </system.data>
+</configuration>

--- a/MemoScope/Core/ClrDump.cs
+++ b/MemoScope/Core/ClrDump.cs
@@ -367,7 +367,7 @@ namespace MemoScope.Core
             {
                 string name = (string)GetFieldValue(threadAddress, threadType, nameField);
                 int priority = (int)GetFieldValue(threadAddress, threadType, priorityField);
-                int id = (int)GetFieldValue(threadAddress, threadType, idField);
+                int id = idField != null ? (int)GetFieldValue(threadAddress, threadType, idField) : 0;
                 threadProperties[id] = new ThreadProperty
                 {
                     Address = threadAddress,

--- a/MemoScope/Core/ClrDump.cs
+++ b/MemoScope/Core/ClrDump.cs
@@ -12,6 +12,7 @@ using WinFwk.UIModules;
 using NLog;
 using System.Reflection;
 using MemoScope.Core.ProcessInfo;
+using ClrObject = MemoScope.Core.Data.ClrObject;
 
 namespace MemoScope.Core
 {
@@ -24,12 +25,12 @@ namespace MemoScope.Core
         public ClrRuntime Runtime { get; set; }
         public DataTarget Target { get; }
         public string DumpPath { get; }
-        public ClrHeap Heap => Runtime.GetHeap();
+        public ClrHeap Heap => Runtime.Heap;
 
         public MessageBus MessageBus { get; }
         public ClrDumpInfo ClrDumpInfo { get; }
 
-        public IList<ClrSegment> Segments => Runtime.GetHeap().Segments;
+        public IList<ClrSegment> Segments => Runtime.Heap.Segments;
         public List<ClrMemoryRegion> Regions => Runtime.EnumerateMemoryRegions().ToList();
         public IList<ClrModule> Modules => Runtime.Modules;
 
@@ -37,7 +38,7 @@ namespace MemoScope.Core
         public List<ulong> FinalizerQueueObjectAddresses => Runtime.EnumerateFinalizerQueueObjectAddresses().ToList();
         public IEnumerable<IGrouping<ClrType, ulong>> FinalizerQueueObjectAddressesByType => Runtime.EnumerateFinalizerQueueObjectAddresses().GroupBy(address => GetObjectType(address));
         public IList<ClrThread> Threads => Runtime.Threads;
-        public ClrThreadPool ThreadPool => Runtime.GetThreadPool();
+        public ClrThreadPool ThreadPool => Runtime.ThreadPool;
         public List<ClrType> AllTypes => Heap.EnumerateTypes().ToList();
 
         public Dictionary<int, ThreadProperty> ThreadProperties
@@ -52,7 +53,7 @@ namespace MemoScope.Core
             }
         }
 
-        public IEnumerable<ClrRoot> EnumerateClrRoots => Runtime.GetHeap().EnumerateRoots();
+        public IEnumerable<ClrRoot> EnumerateClrRoots => Runtime.Heap.EnumerateRoots();
 
         Dictionary<int, ThreadProperty> threadProperties;
         private readonly SingleThreadWorker worker;
@@ -460,7 +461,7 @@ namespace MemoScope.Core
             MessageBus.BeginTask("Looking for blocking objects...", source);
 
             int n = 0;
-            foreach (var obj in Runtime.GetHeap().EnumerateBlockingObjects())
+            foreach (var obj in Runtime.Heap.EnumerateBlockingObjects())
             {
                 if (token.IsCancellationRequested)
                 {
@@ -492,7 +493,7 @@ namespace MemoScope.Core
             MessageBus.BeginTask("Looking for ClrRoots...", source);
 
             int n = 0;
-            foreach (var obj in Runtime.GetHeap().EnumerateRoots())
+            foreach (var obj in Runtime.Heap.EnumerateRoots())
             {
                 if (token.IsCancellationRequested)
                 {

--- a/MemoScope/Core/ClrTypeError.cs
+++ b/MemoScope/Core/ClrTypeError.cs
@@ -6,6 +6,7 @@ namespace MemoScope.Core
 {
     public class ClrTypeError : ClrType
     {
+        protected override GCDesc GCDesc { get; }
         public override ulong MethodTable => 0;
         public override uint MetadataToken => 0;
         public override string Name { get; }

--- a/MemoScope/MemoScope.csproj
+++ b/MemoScope/MemoScope.csproj
@@ -111,9 +111,8 @@
       <HintPath>..\packages\ExpressionEvaluator.2.0.4.0\lib\net40\ExpressionEvaluator.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Diagnostics.Runtime, Version=0.8.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Diagnostics.Runtime.0.8.31-beta\lib\net40\Microsoft.Diagnostics.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Diagnostics.Runtime, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Runtime.1.0.5\lib\net45\Microsoft.Diagnostics.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.3\lib\net45\NLog.dll</HintPath>

--- a/MemoScope/MemoScope.csproj
+++ b/MemoScope/MemoScope.csproj
@@ -100,12 +100,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="ExpressionEvaluator, Version=2.0.4.0, Culture=neutral, PublicKeyToken=90d9f15d622e2348, processorArchitecture=MSIL">
       <HintPath>..\packages\ExpressionEvaluator.2.0.4.0\lib\net40\ExpressionEvaluator.dll</HintPath>
@@ -115,8 +113,7 @@
       <HintPath>..\packages\Microsoft.Diagnostics.Runtime.1.0.5\lib\net45\Microsoft.Diagnostics.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.3\lib\net45\NLog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NLog.4.6.4\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="ObjectListView, Version=2.9.1.1072, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
       <HintPath>..\packages\ObjectListView.Official.2.9.1\lib\net20\ObjectListView.dll</HintPath>
@@ -126,26 +123,26 @@
       <HintPath>..\packages\ParallelExtensionsExtras.1.2.0.0\lib\net40\ParallelExtensionsExtras.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ScintillaNET, Version=3.5.10.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\jacobslusser.ScintillaNET.3.5.10\lib\net40\ScintillaNET.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SQLite, Version=1.0.104.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Core.1.0.104.0\lib\net46\System.Data.SQLite.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Data.SQLite, Version=1.0.111.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.111.0\lib\net46\System.Data.SQLite.dll</HintPath>
     </Reference>
-    <Reference Include="System.Data.SQLite.EF6, Version=1.0.104.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.104.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Data.SQLite.EF6, Version=1.0.111.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.111.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
     </Reference>
-    <Reference Include="System.Data.SQLite.Linq, Version=1.0.104.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.104.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Data.SQLite.Linq, Version=1.0.111.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.111.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -156,9 +153,8 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=2.13.0.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
-      <HintPath>..\packages\DockPanelSuite.2.13.0\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
+      <HintPath>..\packages\DockPanelSuite.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
     </Reference>
     <Reference Include="WinFwk, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\fremag.WinFwk.1.0.7\lib\net461\WinFwk.dll</HintPath>
@@ -816,12 +812,12 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\System.Data.SQLite.Core.1.0.104.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.104.0\build\net46\System.Data.SQLite.Core.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.104.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.104.0\build\net46\System.Data.SQLite.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.111.0\build\net46\System.Data.SQLite.Core.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/MemoScope/Modules/Delegates/DelegatesAnalysis.cs
+++ b/MemoScope/Modules/Delegates/DelegatesAnalysis.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using WinFwk.UIModules;
+using ClrObject = MemoScope.Core.Data.ClrObject;
 
 namespace MemoScope.Modules.Delegates
 {

--- a/MemoScope/Modules/Delegates/LoneTargetInformation.cs
+++ b/MemoScope/Modules/Delegates/LoneTargetInformation.cs
@@ -2,6 +2,7 @@
 using BrightIdeasSoftware;
 using MemoScope.Core;
 using Microsoft.Diagnostics.Runtime;
+using ClrObject = MemoScope.Core.Data.ClrObject;
 
 namespace MemoScope.Modules.Delegates
 {

--- a/MemoScope/Modules/InstanceDetails/FieldValueInformation.cs
+++ b/MemoScope/Modules/InstanceDetails/FieldValueInformation.cs
@@ -5,6 +5,7 @@ using MemoScope.Core.Helpers;
 using Microsoft.Diagnostics.Runtime;
 using WinFwk.UITools;
 using System;
+using ClrObject = MemoScope.Core.Data.ClrObject;
 
 namespace MemoScope.Modules.InstanceDetails
 {

--- a/MemoScope/Modules/ThreadPool/ThreadPoolModule.cs
+++ b/MemoScope/Modules/ThreadPool/ThreadPoolModule.cs
@@ -1,4 +1,5 @@
-﻿using MemoScope.Core;
+﻿using System;
+using MemoScope.Core;
 using MemoScope.Core.Helpers;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,7 +34,17 @@ namespace MemoScope.Modules.ThreadPool
         {
             ThreadPoolInformation = new ThreadPoolInformation(ClrDump, ClrDump.ThreadPool);
             NativeWorkItems = ClrDump.ThreadPool.EnumerateNativeWorkItems().Select(workItem => new NativeWorkItemInformation(workItem)).ToList();
-            ManagedWorkItems = ClrDump.ThreadPool.EnumerateManagedWorkItems().Select(workItem => new ManagedWorkItemInformation(workItem)).ToList();
+
+            try
+            {
+                ManagedWorkItems = ClrDump.ThreadPool.EnumerateManagedWorkItems().Select(workItem => new ManagedWorkItemInformation(workItem)).ToList();
+            }
+            catch (Exception)
+            {
+                // ClrMd does not yet support EnumerateManagedWorkItems with .net core dumps
+                // see: https://github.com/Microsoft/clrmd/issues/131
+                ManagedWorkItems = null;
+            }
         }
 
         public override void PostInit()

--- a/MemoScope/packages.config
+++ b/MemoScope/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net46" />
-  <package id="DockPanelSuite" version="2.13.0" targetFramework="net461" />
-  <package id="EntityFramework" version="6.1.3" targetFramework="net46" />
+  <package id="DockPanelSuite" version="3.0.6" targetFramework="net461" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="ExpressionEvaluator" version="2.0.4.0" targetFramework="net46" />
   <package id="fremag.WinFwk" version="1.0.7" targetFramework="net461" />
-  <package id="jacobslusser.ScintillaNET" version="3.5.10" targetFramework="net461" />
+  <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net461" />
   <package id="Microsoft.Diagnostics.Runtime" version="1.0.5" targetFramework="net461" />
-  <package id="NLog" version="4.4.3" targetFramework="net461" />
+  <package id="NLog" version="4.6.4" targetFramework="net461" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net461" />
   <package id="ParallelExtensionsExtras" version="1.2.0.0" targetFramework="net46" />
-  <package id="System.Data.SQLite" version="1.0.104.0" targetFramework="net461" />
-  <package id="System.Data.SQLite.Core" version="1.0.104.0" targetFramework="net461" />
-  <package id="System.Data.SQLite.EF6" version="1.0.104.0" targetFramework="net461" />
-  <package id="System.Data.SQLite.Linq" version="1.0.104.0" targetFramework="net461" />
+  <package id="System.Data.SQLite" version="1.0.111.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.Core" version="1.0.111.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.EF6" version="1.0.111.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.Linq" version="1.0.111.0" targetFramework="net461" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/MemoScope/packages.config
+++ b/MemoScope/packages.config
@@ -6,7 +6,7 @@
   <package id="ExpressionEvaluator" version="2.0.4.0" targetFramework="net46" />
   <package id="fremag.WinFwk" version="1.0.7" targetFramework="net461" />
   <package id="jacobslusser.ScintillaNET" version="3.5.10" targetFramework="net461" />
-  <package id="Microsoft.Diagnostics.Runtime" version="0.8.31-beta" targetFramework="net46" />
+  <package id="Microsoft.Diagnostics.Runtime" version="1.0.5" targetFramework="net461" />
   <package id="NLog" version="4.4.3" targetFramework="net461" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net461" />
   <package id="ParallelExtensionsExtras" version="1.2.0.0" targetFramework="net46" />

--- a/UnitTestProject/UnitTestProject.csproj
+++ b/UnitTestProject/UnitTestProject.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,6 +18,8 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,31 +76,34 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Diagnostics.Runtime, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Diagnostics.Runtime.1.0.5\lib\net45\Microsoft.Diagnostics.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.1\lib\net45\NLog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\NLog.4.6.4\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="ObjectListView, Version=2.9.1.1072, Culture=neutral, PublicKeyToken=b1c5bf581481bcd4, processorArchitecture=MSIL">
       <HintPath>..\packages\ObjectListView.Official.2.9.1\lib\net20\ObjectListView.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=2.13.0.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
-      <HintPath>..\packages\DockPanelSuite.2.13.0\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Xml" />
+    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
+      <HintPath>..\packages\DockPanelSuite.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
     </Reference>
-    <Reference Include="WinFwk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\fremag.WinFwk.1.0.0\lib\net461\WinFwk.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WinFwk, Version=1.0.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\fremag.WinFwk.1.0.7\lib\net461\WinFwk.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -173,6 +179,12 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/UnitTestProject/UnitTestProject.csproj
+++ b/UnitTestProject/UnitTestProject.csproj
@@ -73,9 +73,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Diagnostics.Runtime, Version=0.8.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Diagnostics.Runtime.0.8.31-beta\lib\net40\Microsoft.Diagnostics.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Diagnostics.Runtime, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Runtime.1.0.5\lib\net45\Microsoft.Diagnostics.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.1\lib\net45\NLog.dll</HintPath>

--- a/UnitTestProject/app.config
+++ b/UnitTestProject/app.config
@@ -1,11 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="ObjectListView" publicKeyToken="b1c5bf581481bcd4" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.9.0.25611" newVersion="2.9.0.25611"/>
+        <assemblyIdentity name="ObjectListView" publicKeyToken="b1c5bf581481bcd4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.9.0.25611" newVersion="2.9.0.25611" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WeifenLuo.WinFormsUI.Docking" publicKeyToken="5cded1a1a0a7b481" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.6.0" newVersion="3.0.6.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/UnitTestProject/packages.config
+++ b/UnitTestProject/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="DockPanelSuite" version="2.13.0" targetFramework="net461" />
   <package id="fremag.WinFwk" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Diagnostics.Runtime" version="0.8.31-beta" targetFramework="net46" />
+  <package id="Microsoft.Diagnostics.Runtime" version="1.0.5" targetFramework="net461" />
   <package id="NLog" version="4.4.1" targetFramework="net461" />
   <package id="NUnit" version="3.2.0" targetFramework="net46" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net461" />

--- a/UnitTestProject/packages.config
+++ b/UnitTestProject/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DockPanelSuite" version="2.13.0" targetFramework="net461" />
-  <package id="fremag.WinFwk" version="1.0.0" targetFramework="net461" />
+  <package id="DockPanelSuite" version="3.0.6" targetFramework="net461" />
+  <package id="fremag.WinFwk" version="1.0.7" targetFramework="net461" />
   <package id="Microsoft.Diagnostics.Runtime" version="1.0.5" targetFramework="net461" />
-  <package id="NLog" version="4.4.1" targetFramework="net461" />
-  <package id="NUnit" version="3.2.0" targetFramework="net46" />
+  <package id="NLog" version="4.6.4" targetFramework="net461" />
+  <package id="NUnit" version="3.12.0" targetFramework="net461" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This tool is absolutely great.  Thank you very much for it!

There are some issues with working with .net core memory dumps, mostly due to ClrMd not yet supporting them fully.  These changes fix several issues when trying to load root objects, viewing the threads, threadpool, etc.